### PR TITLE
WIP Remove Conjur::Rack::User#new_association

### DIFF
--- a/lib/conjur/rack/user.rb
+++ b/lib/conjur/rack/user.rb
@@ -29,10 +29,6 @@ module Conjur
       alias :conjur_account :account
       # alias :conjur_account= :account=
       
-      def new_association(cls, params = {})
-        cls.new params.merge({userid: login})
-      end
-      
       # Returns the global privilege which was present on the request, if and only
       # if the user actually has that privilege.
       #

--- a/spec/rack/user_spec.rb
+++ b/spec/rack/user_spec.rb
@@ -25,15 +25,6 @@ describe Conjur::Rack::User do
     expect(user.login).to eq login
   end
   
-  describe '#new_assocation' do
-    let(:associate){ Class.new }
-    let(:params){{foo: 'bar'}}
-    it "calls cls.new with params including userid: login" do
-      expect(associate).to receive(:new).with(params.merge(userid: subject.login))
-      subject.new_association(associate, params)
-    end
-  end
-  
   describe '#roleid' do
     let(:login){ tokens.join('/') }
 


### PR DESCRIPTION
It's not clear what was the intent behind this method, but there is
no documentation and no usage as far as I can tell.