### PR TITLE
Bump `slosilo` to v2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # unreleased version
 
+# v4.1.0
+
+* Bump `slosilo` to v2.2 in order to be FIPS compliant
+
 # v4.0.0
 
 * Bump `rack` to v2, `bundler` to v1.16 in gemspec

--- a/lib/conjur/rack/version.rb
+++ b/lib/conjur/rack/version.rb
@@ -1,5 +1,5 @@
 module Conjur
   module Rack
-    VERSION = "4.0.0"
+    VERSION = "4.1.0"
   end
 end


### PR DESCRIPTION
In order to be FIPS compliant consume slosilo 2.2