### PR TITLE
Bump `slosilo` to v2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # unreleased version
 
+# v4.1.0
+
+* Bump `slosilo` to v2.2 in order to be FIPS compliant
+
 # v4.0.0
 
 * Bump `rack` to v2, `bundler` to v1.16 in gemspec

--- a/conjur-rack.gemspec
+++ b/conjur-rack.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "slosilo"
+  spec.add_dependency "slosilo", "~> 2.2"
   spec.add_dependency "conjur-api", "< 6"
-  spec.add_dependency "rack"
+  spec.add_dependency "rack", "~> 2"
 
-  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency 'ci_reporter_rspec'

--- a/lib/conjur/rack/version.rb
+++ b/lib/conjur/rack/version.rb
@@ -1,5 +1,5 @@
 module Conjur
   module Rack
-    VERSION = "4.0.0"
+    VERSION = "4.1.0"
   end
 end

--- a/test.sh
+++ b/test.sh
@@ -9,4 +9,4 @@ docker run --rm \
   -w /usr/src/app \
   -e CONJUR_ENV=ci \
   $TEST_IMAGE \
-  bash -c "gem update --system && gem install bundler && bundle update && bundle exec rake spec"
+  bash -c "gem update --system && gem uninstall -i /usr/local/lib/ruby/gems/2.3.0 bundler && gem install bundler -v 1.16.0 && bundle update && bundle exec rake spec"


### PR DESCRIPTION
In order to be FIPS compliant consume slosilo 2.2

**IMPORTANT**
During version change noticed that some changes were not published since 4.0.0 - April 06, 2018.
See [pr 14](https://github.com/cyberark/conjur-rack/pull/14)

- The change in `test.sh` includes uninstall previous bundler versions:

`gem uninstall -i /usr/local/lib/ruby/gems/2.3.0 bundler`
since 1.15 collide with 1.16.

Another possible approach was to specify the version for any bundler command i.e. `bundler 1.16.0 update`

- Also, reapply versions number that were omitted from `gemspec`
cause wrong version specifier in ruby-gems
![image](https://user-images.githubusercontent.com/40024474/85281235-4c817980-b492-11ea-83e4-0e4df1182ed9.png)
