### PR TITLE
Bump `slosilo` to v2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased version
 
-# v4.1.0
+# v4.2.0
 
 * Bump `slosilo` to v2.2 in order to be FIPS compliant
 

--- a/lib/conjur/rack/version.rb
+++ b/lib/conjur/rack/version.rb
@@ -1,5 +1,5 @@
 module Conjur
   module Rack
-    VERSION = "4.1.0"
+    VERSION = "4.2.0"
   end
 end


### PR DESCRIPTION
In order to be FIPS compliant consume slosilo 2.2

Can't override 4.1.0 version. Bump to 4.2.0
https://help.rubygems.org/kb/gemcutter/removing-a-published-rubygem