### PR TITLE
Upgrade bundler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # unreleased version
 
+* Bump `bundler` to v2.1.4 to resolve CVE-2019-3881 
+  [cyberark/conjur-rack#23](https://github.com/cyberark/conjur-rack/issues/23)
+
 # v4.2.0
 
 * Bump `slosilo` to v2.2 in order to be FIPS compliant

--- a/conjur-rack.gemspec
+++ b/conjur-rack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "conjur-api", "< 6"
   spec.add_dependency "rack", "~> 2"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.1.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency 'ci_reporter_rspec'

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 TEST_IMAGE='ruby:2.3.4'
+BUNDLER_VERSION="2.1.4"
 
 rm -f Gemfile.lock
 
@@ -8,5 +9,6 @@ docker run --rm \
   -v "$PWD:/usr/src/app" \
   -w /usr/src/app \
   -e CONJUR_ENV=ci \
+  -e BUNDLER_VERSION=$BUNDLER_VERSION \
   $TEST_IMAGE \
-  bash -c "gem update --system && gem uninstall -i /usr/local/lib/ruby/gems/2.3.0 bundler && gem install bundler -v 1.16.0 && bundle update && bundle exec rake spec"
+  bash -c "gem update --system && gem uninstall -i /usr/local/lib/ruby/gems/2.3.0 bundler && gem install bundler -v $BUNDLER_VERSION && bundle update && bundle exec rake spec"


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Bundler before 2.1.0 has an issue that Dependabot is flagging. This PR updates Bundler to close that vulnerability.

### What ticket does this PR close?
Resolves #23 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
