### PR TITLE
Upgrade bundler to 2.2.18 to resolve CVE-2020-36327 and CVE-2019-3881

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     // Only publish to RubyGems if the HEAD is
     // tagged with the same version as in version.rb
     stage('Publish to RubyGems') {
-      agent { label 'releaser-v2' }
+      agent { label 'executor-v2' }
 
       when {
         expression { currentBuild.resultIsBetterOrEqualTo('SUCCESS') }

--- a/conjur-rack.gemspec
+++ b/conjur-rack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "conjur-api", "< 6"
   spec.add_dependency "rack", "~> 2"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.2.18"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency 'ci_reporter_rspec'

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-TEST_IMAGE='ruby:2.3.4'
+TEST_IMAGE='ruby:2.5'
 
 rm -f Gemfile.lock
 
@@ -9,4 +9,4 @@ docker run --rm \
   -w /usr/src/app \
   -e CONJUR_ENV=ci \
   $TEST_IMAGE \
-  bash -c "gem update --system && gem uninstall -i /usr/local/lib/ruby/gems/2.3.0 bundler && gem install bundler -v 1.16.0 && bundle update && bundle exec rake spec"
+  bash -c "gem update --system && gem install bundler:2.2.18 && bundle update && bundle exec rake spec"


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Updates Bundler to 2.2.18 to resolve CVEs around supply chain attacks
- Upgrades Ruby in the test.sh container to use 2.5
- Changes the Jenkinsfile to use a releaser-v2 node instead of an executor-v2 node which no longer works (hangs on the publish stage)

### What ticket does this PR close?
Resolves #23

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
