### PR TITLE
Bump to V5.0.0 with Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # unreleased version
 
+# v5.0.0
+
+* Support Ruby 3.
+* Bump `slosilo` to v3.0 with ruby 3.
+* Remove pinned `bundler` version, use default system bundler.
+
 # v4.2.0
 
 * Bump `slosilo` to v2.2 in order to be FIPS compliant

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # make sure github uses TLS
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 
-#ruby=ruby-2.3.4
+#ruby=ruby-3.0
 #ruby-gemset=conjur-rack
 
 # Specify your gem's dependencies in conjur-rack.gemspec

--- a/conjur-rack.gemspec
+++ b/conjur-rack.gemspec
@@ -18,13 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "slosilo", "~> 2.2"
+  spec.add_dependency "slosilo", "~> 3.0"
   spec.add_dependency "conjur-api", "< 6"
   spec.add_dependency "rack", "~> 2"
-
-  spec.add_development_dependency "bundler", "~> 2.2.18"
+  
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "activesupport", "< 7"
   spec.add_development_dependency 'ci_reporter_rspec'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rspec-its'

--- a/lib/conjur/rack/version.rb
+++ b/lib/conjur/rack/version.rb
@@ -1,5 +1,5 @@
 module Conjur
   module Rack
-    VERSION = "4.2.0"
+    VERSION = "5.0.0"
   end
 end

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-TEST_IMAGE='ruby:2.5'
+TEST_IMAGE='ruby:3.0'
 
 rm -f Gemfile.lock
 
@@ -9,4 +9,4 @@ docker run --rm \
   -w /usr/src/app \
   -e CONJUR_ENV=ci \
   $TEST_IMAGE \
-  bash -c "gem update --system && gem install bundler:2.2.18 && bundle update && bundle exec rake spec"
+  bash -c "gem update --system && bundle update && bundle exec rake spec"


### PR DESCRIPTION
### Desired Outcome

The code in this repository runs on Ruby 3.
All relevant gems consumed by this repository are ruby 3 compatible.

### Implemented Changes

Updated slosilo to V3.0.0.
Updated test script to run with ruby 3.

### Connected Issue/Story

Related to promotion of conjur-oss to ruby-3. (consumes conjur-rack as a gem)
Internal CyberArk issue [ONYX-14080](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14080).

### Definition of Done
All tests are passing.
New gem V5.0.0 is released.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
