### PR TITLE
CONJSE-1802: Migrating to release-tools/publish.sh

### DIFF
--- a/conjur-rack.gemspec
+++ b/conjur-rack.gemspec
@@ -13,20 +13,24 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/conjurinc/conjur-rack"
   spec.license       = "Private"
 
-  spec.files         = `git ls-files`.split($/)
+  #spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($\)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_dependency "slosilo", "~> 3.0"
-  spec.add_dependency "conjur-api", "< 6"
-  spec.add_dependency "rack", "~> 2"
+  spec.add_dependency "conjur-api", "~> 5.4"
+  spec.add_dependency "rack", "~> 3.0"
   
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "activesupport", "< 7"
+  spec.add_development_dependency "rspec-rails", "~> 6.1"
+  spec.add_development_dependency "bundler", "~> 2.4"
+  spec.add_development_dependency "rake", "~> 13.1"
+  spec.add_development_dependency "rspec", "~> 3.12"
+  spec.add_development_dependency "spec", "~> 5.3"
+  spec.add_development_dependency "activesupport", "~> 7.1"
   spec.add_development_dependency 'ci_reporter_rspec'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rspec-its'
+  spec.add_development_dependency 'pry-byebug', "~> 3.10"
+  spec.add_development_dependency 'rspec-its', "~> 1.3"
 
 end

--- a/publish.sh
+++ b/publish.sh
@@ -1,7 +1,14 @@
 #!/bin/bash -ex
 
-docker pull registry.tld/conjurinc/publish-rubygem
+echo "*** Starting Publish"
 
+git clone git@github.com:conjurinc/release-tools.git
+
+export PATH=$PWD/release-tools/bin/:$PATH
+
+echo "***--- Starting Summon"
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
-  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-  registry.tld/conjurinc/publish-rubygem conjur-rack
+  publish-rubygem conjur-rack
+echo "***--- Finished Summon"
+
+echo "*** Finished Publish"

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,14 @@
-#!/bin/bash -e
+#!/bin/bash -eux
 
-TEST_IMAGE='ruby:3.0'
+echo "==> Starting test.sh"
 
 rm -f Gemfile.lock
 
+echo "==> Docker Run"
+
 docker run --rm \
-  -v "$PWD:/usr/src/app" \
-  -w /usr/src/app \
-  -e CONJUR_ENV=ci \
-  $TEST_IMAGE \
-  bash -c "gem update --system && bundle update && bundle exec rake spec"
+    --volume $PWD:/usr/src/app \
+    --workdir /usr/src/app cyberark/ubuntu-ruby-builder \
+    bash -c 'git config --global --add safe.directory /usr/src/app && apt update && apt search libyaml && apt install libyaml-dev && gem update --system && bundle install && gem install spec && bundle install && bundle update && bundle exec rspec' 
+
+echo "==> End of test.sh"


### PR DESCRIPTION

Remove remaining dependencies on conjurinc/publish_rubygem container

    https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJSE-1802

Migrated from github.com to GitHub Enterprise.
Changes made for CVE-2023-5129

    Updated to use Ruby ~> 3.0
    Updated to use conjur-enterprise/release-tools/publish-rubygem

