### PR TITLE
Add logging for 403 and 401 status

### DIFF
--- a/lib/conjur/rack/authenticator.rb
+++ b/lib/conjur/rack/authenticator.rb
@@ -11,16 +11,16 @@ module Conjur
       def identity?
         !conjur_rack[:identity].nil?
       end
-      
+
       def user
-        User.new(identity[0], identity[1], 
-          :privilege => privilege, 
-          :remote_ip => remote_ip, 
-          :audit_roles => audit_roles, 
+        User.new(identity[0], identity[1],
+          :privilege => privilege,
+          :remote_ip => remote_ip,
+          :audit_roles => audit_roles,
           :audit_resources => audit_resources
           )
       end
-      
+
       def identity
         conjur_rack[:identity] or raise "No Conjur identity for current request"
       end
@@ -33,7 +33,7 @@ module Conjur
       end
     end
 
-  
+
     class Authenticator
       class AuthorizationError < SecurityError
       end
@@ -41,9 +41,9 @@ module Conjur
       end
       class Forbidden < SecurityError
       end
-      
+
       attr_reader :app, :options
-      
+
       # +options+:
       # :except :: a list of request path patterns for which to skip authentication.
       # :optional :: request path patterns for which authentication is optional.
@@ -61,14 +61,14 @@ module Conjur
           conjur_rack[a]
         end
       end
- 
+
       def call rackenv
-        # never store request-specific variables as application attributes 
+        # never store request-specific variables as application attributes
         Thread.current[:rack_env] = rackenv
         if authenticate?
           begin
             identity = verify_authorization_and_get_identity # [token, account]
-            
+
             if identity
               conjur_rack[:token] = identity[0]
               conjur_rack[:account] = identity[1]
@@ -80,21 +80,25 @@ module Conjur
             end
 
           rescue Forbidden
-            return error 403, $!.message
+            @auth_error = error 403, $!.message
           rescue SecurityError, RestClient::Exception
-            return error 401, $!.message
+            @auth_error = error 401, $!.message
           end
         end
         begin
+          if @auth_error
+            Rails.logger.info("Completed #{@auth_error[0]} #{@auth_error[2]}")
+            return @auth_error
+          end
           @app.call rackenv
         ensure
           Thread.current[:rack_env] = nil
           Thread.current[:conjur_rack] = {}
         end
       end
-      
+
       protected
-      
+
       def conjur_rack
         Conjur::Rack.conjur_rack
       end
@@ -109,7 +113,7 @@ module Conjur
           $1
         end
       end
-      
+
       def error status, message
         [status, { 'Content-Type' => 'text/plain', 'Content-Length' => message.length.to_s }, [message] ]
       end
@@ -121,7 +125,7 @@ module Conjur
       rescue JSON::ParserError
         raise AuthorizationError.new("Malformed authorization token")
       end
-      
+
       RECOGNIZED_CLAIMS = [
         'iat', 'exp', # recognized by Slosilo
         'cidr', 'sub',
@@ -152,7 +156,7 @@ module Conjur
           end
         end
       end
-      
+
       def authenticate?
         path = http_path
         if options[:except]
@@ -161,7 +165,7 @@ module Conjur
           true
         end
       end
-      
+
       def optional_paths
         options[:optional] || []
       end


### PR DESCRIPTION
### Desired Outcome

Log when a 403 status occurs during authentication.

### Implemented Changes

Upon inspection, 401 statuses were found to also not be logged. Calls to the logger were inserted into the Authenticator middleware rack upon a 403 and 401 status result.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
